### PR TITLE
Map.fold ya no se usa

### DIFF
--- a/src/Env.hs
+++ b/src/Env.hs
@@ -79,7 +79,7 @@ envGet key env = getKey (envRibs env)
         _            -> Nothing
 
 envAllValues :: Env a b -> [b]
-envAllValues = Map.fold (++) [] . envRibs
+envAllValues = foldr (++) [] . envRibs
 
 envFromList :: Ord a => [(a, b)] -> Env a b
 envFromList = foldr (uncurry envDefine) envEmpty


### PR DESCRIPTION
No es nada grave, pero me parece importante remarcarlo.

De acá saqué la advertencia:

```make
$ make
ghc -isrc --make src/Main.hs -o qr -rtsopts
[ 1 of 29] Compiling AST              ( src/AST.hs, src/AST.o )
[ 2 of 29] Compiling Backend.C_MM     ( src/Backend/C_MM.hs, src/Backend/C_MM.o )
[ 3 of 29] Compiling Backend.JvmClass ( src/Backend/JvmClass.hs, src/Backend/JvmClass.o )
[ 4 of 29] Compiling Env              ( src/Env.hs, src/Env.o )

src/Env.hs:82:16: warning: [-Wdeprecations]
    In the use of ‘fold’ (imported from Data.Map):
    Deprecated: "As of version 0.5, replaced by 'foldr'."
   |
82 | envAllValues = Map.fold (++) [] . envRibs
   |                ^^^^^^^^
...
...
Linking qr ...
```

Es una pavada, pero fácil de arreglar.